### PR TITLE
controller: allow kubeconfig overrides

### DIFF
--- a/pkg/controller/release/controller.go
+++ b/pkg/controller/release/controller.go
@@ -545,7 +545,8 @@ func (c *Controller) syncHandler(key string) error {
 	// when the secret is not a managed secret.
 	// When a release spec uses managed secret, it must also be running in
 	// user's namespace. (see check above)
-	if !managedSecret {
+	_, found := refSecret.Data[KeyKubeconfig]
+	if !managedSecret && !found {
 		configBytes, err := c.buildKubeConfig(namespace, serviceAccountName)
 		if err != nil {
 			c.recorder.Eventf(release, corev1.EventTypeWarning, "FailedKubeconfig", "failed to build kubeconfig: %s", err)


### PR DESCRIPTION
In `spec.secretRef`, if `kubeconfig` is already specified, then we should just honor it and use it as the kubeconfig going forward. This allows a use case for cross-cluster deployments. In that use case, all the release objects can be specified from one single cluster, but managing all the other clusters via kubeconfig overrides in secretRef. This is a rare case, but might still be useful sometimes.